### PR TITLE
Only create uninstall target if not already existing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,10 +130,12 @@ if(BUILD_DOCS)
 endif()
 
 # ---- uninstall target -------------------------------------------------------
-configure_file(
-	"${CMAKE_CURRENT_SOURCE_DIR}/cmake_uninstall.cmake.in"
-	"${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake"
-	IMMEDIATE @ONLY)
+if(NOT TARGET uninstall)
+	configure_file(
+		"${CMAKE_CURRENT_SOURCE_DIR}/cmake_uninstall.cmake.in"
+		"${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake"
+		IMMEDIATE @ONLY)
 
-add_custom_target(uninstall
-	COMMAND ${CMAKE_COMMAND} -P "${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake")
+	add_custom_target(uninstall
+		COMMAND ${CMAKE_COMMAND} -P "${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake")
+endif()


### PR DESCRIPTION
For fixing this error:

    add_custom_target cannot create target "uninstall" because another target
      with the same name already exists.  The existing target is a custom target
      created in source directory
      "...".  See documentation for policy CMP0002 for more details.