### PR TITLE
fix c api

### DIFF
--- a/src/VMTFile.h
+++ b/src/VMTFile.h
@@ -13,9 +13,13 @@
 #define VTFLIB_VMTFILE_H
 
 #include "stdafx.h"
-#include "Readers.h"
-#include "Writers.h"
-#include "VMTNodes.h"
+#ifdef __cplusplus
+#	include "Readers.h"
+#	include "Writers.h"
+#	include "VMTNodes.h"
+#else
+#	include "VMTNode.h"
+#endif
 
 #ifdef __cplusplus
 extern "C" {
@@ -32,6 +36,8 @@ typedef enum tagVMTParseMode
 #ifdef __cplusplus
 }
 #endif
+
+#ifdef __cplusplus
 
 namespace VTFLib
 {
@@ -72,5 +78,7 @@ namespace VTFLib
 		Nodes::CVMTGroupNode *GetRoot() const;
 	};
 }
+
+#endif
 
 #endif

--- a/src/VMTNode.h
+++ b/src/VMTNode.h
@@ -32,6 +32,8 @@ typedef enum tagVMTNodeType
 }
 #endif
 
+#ifdef __cplusplus
+
 namespace VTFLib
 {
 	namespace Nodes
@@ -61,5 +63,7 @@ namespace VTFLib
 		};
 	}
 }
+
+#endif
 
 #endif

--- a/src/VMTWrapper.h
+++ b/src/VMTWrapper.h
@@ -9,10 +9,11 @@
  * version.
  */
 
-#ifndef VTFLIB_VTFWRAPPER_H
-#define VTFLIB_VTFWRAPPER_H
+#ifndef VTFLIB_VMTWRAPPER_H
+#define VTFLIB_VMTWRAPPER_H
 
 #include "stdafx.h"
+#include "VMTFile.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/VTFFile.h
+++ b/src/VTFFile.h
@@ -21,8 +21,12 @@
 #define VTFLIB_VTFFILE_H
 
 #include "stdafx.h"
-#include "Readers.h"
-#include "Writers.h"
+
+#ifdef __cplusplus
+#	include "Readers.h"
+#	include "Writers.h"
+#endif
+
 #include "VTFFormat.h"
 
 #ifdef __cplusplus
@@ -108,6 +112,7 @@ typedef struct tagSVTFCreateOptions
 }
 #endif
 
+#ifdef __cplusplus
 namespace VTFLib
 {
 	//! VTF File access/creation class.
@@ -751,5 +756,6 @@ namespace VTFLib
 		static vlVoid MirrorImage(vlByte *lpImageDataRGBA8888, vlUInt uiWidth, vlUInt uiHeight);	//!< Flips an image horizontally along its Y-axis.
 	};
 }
+#endif // c++
 
 #endif

--- a/src/VTFFormat.h
+++ b/src/VTFFormat.h
@@ -327,6 +327,8 @@ typedef enum tagVTFResourceEntryType
 
 #pragma pack(1)
 
+#ifdef __cplusplus
+
 //! VTFFileHeader struct.
 /*!
 
@@ -497,6 +499,8 @@ struct SVTFHeader : public SVTFHeader_74_A
 	SVTFResource		Resources[VTF_RSRC_MAX_DICTIONARY_ENTRIES];
 	SVTFResourceData	Data[VTF_RSRC_MAX_DICTIONARY_ENTRIES];
 };
+
+#endif
 
 #pragma pack()
 

--- a/src/VTFLib.h
+++ b/src/VTFLib.h
@@ -100,6 +100,8 @@
 #define VTFLIB_VTFLIB_H
 
 #include "stdafx.h"
+
+#ifdef __cplusplus
 #include "Error.h"
 #include "VTFFile.h"
 #include "VMTFile.h"
@@ -147,6 +149,7 @@ namespace VTFLib
 
 	extern vlUInt uiVMTParseMode;
 }
+#endif
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/VTFWrapper.h
+++ b/src/VTFWrapper.h
@@ -14,6 +14,8 @@
 
 #include "stdafx.h"
 
+#include "VTFFile.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/src/stdafx.h
+++ b/src/stdafx.h
@@ -82,6 +82,12 @@ typedef unsigned __int16	vlUInt16;
 typedef unsigned __int32	vlUInt32;
 typedef unsigned __int64	vlUInt64;
 
+#ifdef __cplusplus
+#	include <cstdint>
+#else
+#	include <stdint.h>
+#endif
+
 #	if _MSC_VER >= 1400
 #		define _CRT_SECURE_NO_WARNINGS
 #		define _CRT_NONSTDC_NO_DEPRECATE
@@ -97,8 +103,6 @@ typedef unsigned __int64	vlUInt64;
 #	endif
 
 #else
-
-#include <cstdint>
 
 typedef off_t	vlOffset;
 typedef off_t	vlSSize;


### PR DESCRIPTION
From my understanding these headers are the only ones that supposed to work with C.

#include "VTFLib.h"
#include "VTFWrapper.h"
#include "VMTWrapper.h"

I would probably have VTFWrapper.h and VMTWrapper.h in VTFLib.h if the compiler is not C++ but I figured that's up to you. 

There are some extern variables in VTFLib.h that I decided to leave out in C because the variables are not prefixed vl and might collide with other variables.