### PR TITLE
Fix linking to txc_dxtn

### DIFF
--- a/src/VTFFile.cpp
+++ b/src/VTFFile.cpp
@@ -81,9 +81,12 @@
  *   GL_COMPRESSED_RGBA_S3TC_DXT5_EXT
  *
  */
-void tx_compress_dxtn(GLint srccomps, GLint width, GLint height,
-					  const GLubyte *srcPixData, GLenum destformat,
-					  GLubyte *dest, GLint dstRowStride);
+
+extern "C" {
+	void tx_compress_dxtn(GLint srccomps, GLint width, GLint height,
+						  const GLubyte *srcPixData, GLenum destformat,
+						  GLubyte *dest, GLint dstRowStride);
+}
 
 #endif
 


### PR DESCRIPTION
Linking to C libraries requires the function to be declared inside an `extern "C"` block, which was missing.