### PR TITLE
move cstdint include outside of windows ifdef

### DIFF
--- a/src/stdafx.h
+++ b/src/stdafx.h
@@ -71,6 +71,12 @@ typedef vlSingle		vlFloat;			//!< Floating point number (same as vlSingled).
 #include <math.h>
 #include <stdarg.h>
 
+#ifdef __cplusplus
+#	include <cstdint>
+#else
+#	include <stdint.h>
+#endif
+
 #ifdef __WINDOWS__
 typedef vlLong				vlOffset;		//!< Seek offset.
 typedef vlUInt				vlSSize;		//!< File size.
@@ -81,12 +87,6 @@ typedef unsigned __int8		vlUInt8;
 typedef unsigned __int16	vlUInt16;
 typedef unsigned __int32	vlUInt32;
 typedef unsigned __int64	vlUInt64;
-
-#ifdef __cplusplus
-#	include <cstdint>
-#else
-#	include <stdint.h>
-#endif
 
 #	if _MSC_VER >= 1400
 #		define _CRT_SECURE_NO_WARNINGS


### PR DESCRIPTION
The include of cstdint was inside a windows ifdef, breaking non-windows builds. This commit fixes that.