### PR TITLE
Fix compilation on Windows

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -35,6 +35,7 @@ set(vtflib_HDRS
 	ProcWriter.h
 	Reader.h
 	Readers.h
+	resource.h
 	stdafx.h
 	VMTFile.h
 	VMTGroupNode.h

--- a/src/ProcReader.cpp
+++ b/src/ProcReader.cpp
@@ -85,7 +85,7 @@ vlSSize CProcReader::GetStreamSize() const
 	if(pReadSizeProc == 0)
 	{
 		LastError.Set("pReadSizeProc not set.");
-		return std::numeric_limits<vlSSize>::max();
+		return (std::numeric_limits<vlSSize>::max)();
 	}
 
 	return pReadSizeProc(this->pUserData);

--- a/src/ProcWriter.cpp
+++ b/src/ProcWriter.cpp
@@ -85,7 +85,7 @@ vlSSize CProcWriter::GetStreamSize() const
 	if(pWriteSizeProc == 0)
 	{
 		LastError.Set("pWriteTellProc not set.");
-		return std::numeric_limits<vlSSize>::max();
+		return (std::numeric_limits<vlSSize>::max)();
 	}
 
 	return pWriteSizeProc(this->pUserData);


### PR DESCRIPTION
Windows has some macros which conflict with `std::numeric_limits::max()`.
Wrapping the function in parenthesis prevents the macro expansion.

Also fixed `resource.h` not being found.
