### PR TITLE
Add option to build as a static library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,8 @@ set(VTFLIB_NAME VTFLib${VTFLIB_MAJOR_VERSION}${VTFLIB_MINOR_VERSION})
 set(VTFLIB_VERSION ${VTFLIB_MAJOR_VERSION}.${VTFLIB_MINOR_VERSION}.${VTFLIB_PATCH_VERSION})
 
 # ---- options ----------------------------------------------------------------
+option(BUILD_SHARED_LIBS "Build shared libraries" ON)
+
 option(USE_NVDXT "(Windows only) VTF creation requires a S3TC implementation.
 For this nvDXTLib can be used and has been tested with version 8.31.1127.1645, availible here:
 http://developer.nvidia.com/object/dds_utilities_legacy.html" OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,6 +68,10 @@ if(NOT(${CMAKE_SYSTEM_NAME} STREQUAL "Windows"))
 	add_definitions(${VTFLIB_PC_CFLAGS})
 endif()
 
+if(BUILD_SHARED_LIBS)
+	add_definitions(-DVTFLIB_USE_DLL)
+endif()
+
 # compiling the library now:
 add_definitions(-DVTFLIB_EXPORTS)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -58,6 +58,7 @@ set(vtflib_HDRS
 
 configure_file(config.h.in "${CMAKE_CURRENT_BINARY_DIR}/config.h" @ONLY)
 configure_file(Resource.rc.in "${CMAKE_CURRENT_BINARY_DIR}/Resource.rc" @ONLY)
+configure_file(resource.h "${CMAKE_CURRENT_BINARY_DIR}/resource.h" COPYONLY)
 
 if(${CMAKE_SYSTEM_NAME} STREQUAL "Windows")
 	add_subdirectory(windows)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -67,7 +67,7 @@ else()
 endif()
 
 add_compiler_export_flags()
-add_library(${VTFLIB_NAME} SHARED
+add_library(${VTFLIB_NAME}
 	${vtflib_SRCS}
 	${vtflib_OS_SRCS}
 	${vtflib_HDRS}

--- a/src/stdafx.h
+++ b/src/stdafx.h
@@ -28,14 +28,18 @@
 #	endif
 #endif
 
-#ifdef __WINDOWS__
-#	ifdef VTFLIB_EXPORTS
-#		define VTFLIB_API __declspec(dllexport)
+#ifdef VTFLIB_USE_DLL
+#	ifdef __WINDOWS__
+#		ifdef VTFLIB_EXPORTS
+#			define VTFLIB_API __declspec(dllexport)
+#		else
+#			define VTFLIB_API __declspec(dllimport)
+#		endif
 #	else
-#		define VTFLIB_API __declspec(dllimport)
+#		define VTFLIB_API __attribute__((visibility("default")))
 #	endif
 #else
-#	define VTFLIB_API __attribute__((visibility("default")))
+#	define VTFLIB_API
 #endif
 
 #ifdef _MSC_VER


### PR DESCRIPTION
Allows to build as a static library if needed, the default is still a shared library.

Also, it still complained about missing `resource.h` on Windows (I thought it worked when I tested it).
Now it definitely won't be missing.