### PR TITLE
Fix compilation under mingw

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,7 +60,7 @@ if(USE_NVDXT AND ${CMAKE_SYSTEM_NAME} STREQUAL "Windows")
 	# TODO: libraries?
 endif()
 
-if(NOT(${CMAKE_SYSTEM_NAME} STREQUAL "Windows"))
+if(UNIX)
 	# big file support (files > 2GB). makes off_t 64bit even on 32bit platforms and makes fseeko/ftello available.
 	set(VTFLIB_PC_CFLAGS "-D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE")
 	add_definitions(${VTFLIB_PC_CFLAGS})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -58,11 +58,14 @@ set(vtflib_HDRS
 
 configure_file(config.h.in "${CMAKE_CURRENT_BINARY_DIR}/config.h" @ONLY)
 configure_file(Resource.rc.in "${CMAKE_CURRENT_BINARY_DIR}/Resource.rc" @ONLY)
+configure_file(resource.h "${CMAKE_CURRENT_BINARY_DIR}/resource.h" COPYONLY)
 
-if(${CMAKE_SYSTEM_NAME} STREQUAL "Windows")
+if(MSVC)
 	add_subdirectory(windows)
+elseif(UNIX)
+  add_subdirectory(unix)
 else()
-	add_subdirectory(unix)
+	add_subdirectory(generic)
 endif()
 
 add_compiler_export_flags()

--- a/src/VTFMathlib.h
+++ b/src/VTFMathlib.h
@@ -28,7 +28,7 @@
 //---------------------------
 #define CACHE_LINE  16									//!< Alignment size.
 
-#ifdef __WINDOWS__
+#ifdef _MSC_VER
 #	define CACHE_ALIGN __declspec(align(CACHE_LINE))	//!< Storage-class information alignment.
 #else
 #	define CACHE_ALIGN __attribute__((aligned (CACHE_LINE)))

--- a/src/generic/CMakeLists.txt
+++ b/src/generic/CMakeLists.txt
@@ -1,0 +1,6 @@
+set(vtflib_OS_SRCS
+	"${CMAKE_CURRENT_SOURCE_DIR}/Error.cpp"
+	"${CMAKE_CURRENT_SOURCE_DIR}/FileReader.cpp"
+	"${CMAKE_CURRENT_SOURCE_DIR}/FileWriter.cpp"
+	"${CMAKE_CURRENT_SOURCE_DIR}/VTFLib.cpp"
+	PARENT_SCOPE)

--- a/src/generic/Error.cpp
+++ b/src/generic/Error.cpp
@@ -1,0 +1,35 @@
+/*
+ * VTFLib
+ * Copyright (C) 2005-2010 Neil Jedrzejewski & Ryan Gregg
+ *               2014      Mathias Panzenböck
+
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later
+ * version.
+ */
+
+#include "../Error.h"
+
+#include "errno.h"
+#include "string.h"
+
+using namespace VTFLib::Diagnostics;
+
+vlVoid CError::Set(const vlChar *cErrorMessage, vlBool bSystemError)
+{
+	vlChar cBuffer[2048];
+	if(bSystemError)
+	{
+		snprintf(cBuffer, sizeof(cBuffer), "Error:\n%s\n\nSystem Error: 0x%.8x:\n%s", cErrorMessage, errno, strerror(errno));
+	}
+	else
+	{
+		snprintf(cBuffer, sizeof(cBuffer), "Error:\n%s", cErrorMessage); 
+	}
+
+	this->Clear();
+	this->cErrorMessage = new vlChar[strlen(cBuffer) + 1];
+	strcpy(this->cErrorMessage, cBuffer);
+}

--- a/src/generic/FileReader.cpp
+++ b/src/generic/FileReader.cpp
@@ -1,0 +1,135 @@
+/*
+ * VTFLib
+ * Copyright (C) 2005-2010 Neil Jedrzejewski & Ryan Gregg
+ *               2021 MihailNaydenov
+
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later
+ * version.
+ */
+
+#include "../VTFLib.h"
+#include "../FileReader.h"
+
+using namespace VTFLib;
+using namespace VTFLib::IO::Readers;
+
+vlBool CFileReader::Open()
+{
+	this->Close();
+
+	this->hFile = fopen(this->cFileName, "rb");
+
+	if(this->hFile == NULL)
+	{
+		LastError.Set("Error opening file.", vlTrue);
+
+		return vlFalse;
+	}
+
+	return vlTrue;
+}
+
+vlVoid CFileReader::Close()
+{
+	if(this->hFile != NULL)
+	{
+		fclose(this->hFile);
+		this->hFile = NULL;
+	}
+}
+
+vlSSize CFileReader::GetStreamSize() const
+{
+	if(this->hFile == NULL)
+	{
+		return 0;
+	}
+
+	const long start_pos = ftell(this->hFile);
+  int err = (start_pos < 0);
+	err |= fseek(this->hFile, 0, SEEK_END);
+  const long end_pos = ftell(this->hFile);
+  err |= (end_pos < 0);
+	const vlSSize file_length = end_pos - start_pos;
+	err |= fseek(this->hFile, start_pos, SEEK_SET);
+
+	if(err != 0) {
+		LastError.Set("GetStreamSize() failed.", vlTrue);
+		return 0;
+	}
+
+	return file_length;
+}
+
+vlSSize CFileReader::GetStreamPointer() const
+{
+	if(this->hFile == NULL)
+	{
+		return 0;
+	}
+
+	long offset = ftell(this->hFile);
+	if(offset < 0)
+	{
+		LastError.Set("GetStreamPointer() failed.", vlTrue);
+		return 0;
+	}
+
+	return offset;
+}
+
+vlSSize CFileReader::Seek(vlOffset lOffset, VLSeekMode uiMode)
+{
+	if(this->hFile == NULL)
+	{
+		return 0;
+	}
+
+	if(fseek(this->hFile, lOffset, uiMode) != 0) {
+		LastError.Set("Seek() failed.", vlTrue);
+		return 0;
+	}
+	return GetStreamPointer();
+}
+
+vlBool CFileReader::Read(vlChar &cChar)
+{
+	if(this->hFile == NULL)
+	{
+		return vlFalse;
+	}
+	
+	int byte = fgetc(this->hFile);
+
+	if(byte == EOF)
+	{
+		LastError.Set("Read() failed.", vlTrue);
+		return vlFalse;
+	}
+	else
+	{
+		cChar = (vlChar)byte;
+		return vlTrue;
+	}
+}
+
+vlSize CFileReader::Read(vlVoid *vData, vlSize uiBytes)
+{
+	if(this->hFile == NULL)
+	{
+		return 0;
+	}
+
+	if(fread(vData, uiBytes, 1, this->hFile) != 1 && ferror(this->hFile))
+	{
+		LastError.Set("Read() failed.", vlTrue);
+		return 0;
+	}
+	else
+	{
+		return uiBytes;
+	}
+}

--- a/src/generic/FileWriter.cpp
+++ b/src/generic/FileWriter.cpp
@@ -1,0 +1,134 @@
+/*
+ * VTFLib
+ * Copyright (C) 2005-2010 Neil Jedrzejewski & Ryan Gregg
+ *               2021 MihailNaydenov
+
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later
+ * version.
+ */
+
+#include <sys/stat.h>
+
+#include "../VTFLib.h"
+#include "../FileWriter.h"
+
+using namespace VTFLib;
+using namespace VTFLib::IO::Writers;
+
+vlBool CFileWriter::Open()
+{
+	this->Close();
+
+	this->hFile = fopen(this->cFileName, "wb");
+
+	if(this->hFile == NULL)
+	{
+		LastError.Set("Error opening file.", vlTrue);
+
+		return vlFalse;
+	}
+
+	return vlTrue;
+}
+
+vlVoid CFileWriter::Close()
+{
+	if(this->hFile != NULL)
+	{
+		fclose(this->hFile);
+		this->hFile = NULL;
+	}
+}
+
+vlSSize CFileWriter::GetStreamSize() const
+{
+	if(this->hFile == NULL)
+	{
+		return 0;
+	}
+
+	const long start_pos = ftell(this->hFile);
+  int err = (start_pos < 0);
+	err |= fseek(this->hFile, 0, SEEK_END);
+  const long end_pos = ftell(this->hFile);
+  err |= (end_pos < 0);
+	const vlSSize file_length = end_pos - start_pos;
+	err |= fseek(this->hFile, start_pos, SEEK_SET);
+
+	if(err != 0) {
+		LastError.Set("GetStreamSize() failed.", vlTrue);
+		return 0;
+	}
+
+	return file_length;
+}
+
+vlSSize CFileWriter::GetStreamPointer() const
+{
+	if(this->hFile == NULL)
+	{
+		return 0;
+	}
+
+	long offset = ftell(this->hFile);
+	if(offset < 0)
+	{
+		LastError.Set("GetStreamPointer() failed.", vlTrue);
+		return 0;
+	}
+
+	return offset;
+}
+
+vlSSize CFileWriter::Seek(vlOffset lOffset, VLSeekMode uiMode)
+{
+	if(this->hFile == NULL)
+	{
+		return 0;
+	}
+
+	if(fseek(this->hFile, lOffset, uiMode) != 0) {
+		LastError.Set("Seek() failed.", vlTrue);
+		return 0;
+	}
+	return GetStreamPointer();
+}
+
+vlBool CFileWriter::Write(vlChar cChar)
+{
+	if(this->hFile == NULL)
+	{
+		return vlFalse;
+	}
+
+	if(fputc(cChar, this->hFile) == EOF)
+	{
+		LastError.Set("Write() failed.", vlTrue);
+		return vlFalse;
+	}
+	else
+	{
+		return vlTrue;
+	}
+}
+
+vlSize CFileWriter::Write(vlVoid *vData, vlSize uiBytes)
+{
+	if(this->hFile == NULL)
+	{
+		return 0;
+	}
+
+	if (fwrite(vData, uiBytes, 1, this->hFile) != 1 && ferror(this->hFile))
+	{
+		LastError.Set("Write() failed.", vlTrue);
+		return 0;
+	}
+	else
+	{
+		return uiBytes;
+	}
+}

--- a/src/generic/VTFLib.cpp
+++ b/src/generic/VTFLib.cpp
@@ -1,0 +1,27 @@
+/*
+ * VTFLib
+ * Copyright (C) 2014 Mathias Panzenböck
+
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later
+ * version.
+ */
+
+#include "../VTFLib.h"
+#include "../VTFFile.h"
+#include "../VMTFile.h"
+
+using namespace VTFLib;
+
+struct LibCallbacks {
+	LibCallbacks() {}
+
+	~LibCallbacks() {
+		vlShutdown();
+	}
+};
+
+// gcc actually calls constructors and destructors of global objects in libraries
+static LibCallbacks libCallbacks;

--- a/src/stdafx.h
+++ b/src/stdafx.h
@@ -77,7 +77,7 @@ typedef vlSingle		vlFloat;			//!< Floating point number (same as vlSingled).
 #	include <stdint.h>
 #endif
 
-#ifdef __WINDOWS__
+#ifdef _MSC_VER
 typedef vlLong				vlOffset;		//!< Seek offset.
 typedef vlUInt				vlSSize;		//!< File size.
 typedef vlUInt				vlSize;			//!< General size.
@@ -125,7 +125,7 @@ typedef FILE*	vlFile;
 
 typedef enum tagVLSeekMode
 {
-#ifdef __WINDOWS__
+#ifdef _MSC_VER
 	SEEK_MODE_BEGIN = FILE_BEGIN,
 	SEEK_MODE_CURRENT = FILE_CURRENT,
 	SEEK_MODE_END = FILE_END


### PR DESCRIPTION
This PR enables the compilation under mingw in Windows. 
It adds a platform agnostic Reader and Writer (99% based on the unix ones) as well as making all "Windows" variations be "MSVC"-based. 
This could be not good enough for some (one might Windows APIs with non MS compiler), but is the simplest, arguably non-breaking solution.