### PR TITLE
Update libtxc_dxtn to a working repo link and add build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,30 @@ However, all read-only features are supported.
 
 ### Dependencies
 
- * [libtxc\_dxtn](http://cgit.freedesktop.org/~mareko/libtxc_dxtn/) for writing S3TC
+ * [libtxc\_dxtn](https://people.freedesktop.org/~cbrill/libtxc_dxtn/) for writing S3TC
    compressed textures (optional).
+   
+<details><summary>Installation</summary><p>
+	
+*From https://askubuntu.com/questions/1033209/libtxc-dxtn-libtxc-dxtni386-not-found-in-ppa-18-04-bionic#1047591*
+```
+# required stuff
+sudo apt-get install mesa-common-dev
+# get source files
+cd ~/
+wget https://people.freedesktop.org/~cbrill/libtxc_dxtn/libtxc_dxtn-1.0.1.tar.gz
+tar xvfz libtxc_dxtn-1.0.1.tar.gz
+cd libtxc_dxtn-1.0.1
+# start the job
+./configure
+make
+sudo make install
+# clean up sources (optional)
+cd ..
+rm -rf libtxc_dxtn-1.0.1 libtxc_dxtn-1.0.1.tar.gz
+```
+
+</p></details>
 
 ### Documentation
 


### PR DESCRIPTION
- Libtxc_dxtn compiling

```
tar xvfz libtxc_dxtn-1.0.1.tar.gz 
libtxc_dxtn-1.0.1/
libtxc_dxtn-1.0.1/configure.ac
libtxc_dxtn-1.0.1/Makefile.in
libtxc_dxtn-1.0.1/Makefile.am
libtxc_dxtn-1.0.1/configure
libtxc_dxtn-1.0.1/txc_dxtn.h
libtxc_dxtn-1.0.1/txc_fetch_dxtn.c
libtxc_dxtn-1.0.1/txc_compress_dxtn.c
libtxc_dxtn-1.0.1/aclocal.m4
libtxc_dxtn-1.0.1/build-aux/
libtxc_dxtn-1.0.1/build-aux/install-sh
libtxc_dxtn-1.0.1/build-aux/config.sub
libtxc_dxtn-1.0.1/build-aux/ltmain.sh
libtxc_dxtn-1.0.1/build-aux/missing
libtxc_dxtn-1.0.1/build-aux/config.guess

pm  ~/    10:51  cd libtxc_dxtn-1.0.1 

pm  ~/ /libtxc_dxtn-1.0.1   10:51  ./configure 
checking for a BSD-compatible install... /usr/bin/install -c
checking whether build environment is sane... yes
checking for a thread-safe mkdir -p... /usr/bin/mkdir -p
checking for gawk... gawk
checking whether make sets $(MAKE)... yes
checking for gcc... gcc
checking whether the C compiler works... yes
checking for C compiler default output file name... a.out
checking for suffix of executables... 
checking whether we are cross compiling... no
checking for suffix of object files... o
checking whether we are using the GNU C compiler... yes
checking whether gcc accepts -g... yes
checking for gcc option to accept ISO C89... none needed
checking build system type... x86_64-unknown-linux-gnu
checking host system type... x86_64-unknown-linux-gnu
checking how to print strings... printf
checking for a sed that does not truncate output... /usr/bin/sed
checking for grep that handles long lines and -e... /usr/bin/grep
checking for egrep... /usr/bin/grep -E
checking for fgrep... /usr/bin/grep -F
checking for ld used by gcc... /usr/bin/ld
checking if the linker (/usr/bin/ld) is GNU ld... yes
checking for BSD- or MS-compatible name lister (nm)... /usr/bin/nm -B
checking the name lister (/usr/bin/nm -B) interface... BSD nm
checking whether ln -s works... yes
checking the maximum length of command line arguments... 1572864
checking whether the shell understands some XSI constructs... yes
checking whether the shell understands "+="... yes
checking how to convert x86_64-unknown-linux-gnu file names to x86_64-unknown-linux-gnu format... func_convert_file_noop
checking how to convert x86_64-unknown-linux-gnu file names to toolchain format... func_convert_file_noop
checking for /usr/bin/ld option to reload object files... -r
checking for objdump... objdump
checking how to recognize dependent libraries... pass_all
checking for dlltool... no
checking how to associate runtime and link libraries... printf %s\n
checking for ar... ar
checking for archiver @FILE support... @
checking for strip... strip
checking for ranlib... ranlib
checking command to parse /usr/bin/nm -B output from gcc object... ok
checking for sysroot... no
checking for mt... no
checking if : is a manifest tool... no
checking how to run the C preprocessor... gcc -E
checking for ANSI C header files... yes
checking for sys/types.h... yes
checking for sys/stat.h... yes
checking for stdlib.h... yes
checking for string.h... yes
checking for memory.h... yes
checking for strings.h... yes
checking for inttypes.h... yes
checking for stdint.h... yes
checking for unistd.h... yes
checking for dlfcn.h... yes
checking for objdir... .libs
checking if gcc supports -fno-rtti -fno-exceptions... no
checking for gcc option to produce PIC... -fPIC -DPIC
checking if gcc PIC flag -fPIC -DPIC works... yes
checking if gcc static flag -static works... no
checking if gcc supports -c -o file.o... yes
checking if gcc supports -c -o file.o... (cached) yes
checking whether the gcc linker (/usr/bin/ld -m elf_x86_64) supports shared libraries... yes
checking whether -lc should be explicitly linked in... no
checking dynamic linker characteristics... GNU/Linux ld.so
checking how to hardcode library paths into programs... immediate
checking whether stripping libraries is possible... yes
checking if libtool supports shared libraries... yes
checking whether to build shared libraries... yes
checking whether to build static libraries... no
configure: creating ./config.status
config.status: creating Makefile
config.status: executing libtool commands

pm  ~/ /libtxc_dxtn-1.0.1   10:52  make
  CC     txc_compress_dxtn.lo
  CC     txc_fetch_dxtn.lo
  CCLD   libtxc_dxtn.la

pm  ~/ /libtxc_dxtn-1.0.1   10:52  sudo make install
doas (pm@vix) password: 
make[1]: Entering directory '/home/pm/Documents/libtxc_dxtn-1.0.1'
test -z "/usr/local/lib" || /usr/bin/mkdir -p "/usr/local/lib"
 /bin/sh ./libtool   --mode=install /usr/bin/install -c   libtxc_dxtn.la '/usr/local/lib'
libtool: install: /usr/bin/install -c .libs/libtxc_dxtn.so /usr/local/lib/libtxc_dxtn.so
libtool: install: /usr/bin/install -c .libs/libtxc_dxtn.lai /usr/local/lib/libtxc_dxtn.la
libtool: finish: PATH="/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin:/sbin" ldconfig -n /usr/local/lib
----------------------------------------------------------------------
Libraries have been installed in:
   /usr/local/lib

If you ever happen to want to link against installed libraries
in a given directory, LIBDIR, you must either use libtool, and
specify the full pathname of the library, or use the `-LLIBDIR'
flag during linking and do at least one of the following:
   - add LIBDIR to the `LD_LIBRARY_PATH' environment variable
     during execution
   - add LIBDIR to the `LD_RUN_PATH' environment variable
     during linking
   - use the `-Wl,-rpath -Wl,LIBDIR' linker flag
   - have your system administrator add LIBDIR to `/etc/ld.so.conf'

See any operating system documentation about shared libraries for
more information, such as the ld(1) and ld.so(8) manual pages.
----------------------------------------------------------------------
test -z "/usr/local/include" || /usr/bin/mkdir -p "/usr/local/include"
 /usr/bin/install -c -m 644 txc_dxtn.h '/usr/local/include'
make[1]: Leaving directory '/home/pm/Documents/libtxc_dxtn-1.0.1'

```

- VTFLib compilation
```
pm  …/VTFLib/build   master   10:52  make -j`nproc`
[  3%] Building CXX object src/CMakeFiles/VTFLib13.dir/FileReader.cpp.o
[  7%] Building CXX object src/CMakeFiles/VTFLib13.dir/MemoryReader.cpp.o
[ 15%] Building CXX object src/CMakeFiles/VTFLib13.dir/Float16.cpp.o
[ 19%] Building CXX object src/CMakeFiles/VTFLib13.dir/Error.cpp.o
[ 26%] Building CXX object src/CMakeFiles/VTFLib13.dir/ProcReader.cpp.o
[ 26%] Building CXX object src/CMakeFiles/VTFLib13.dir/Proc.cpp.o
[ 26%] Building CXX object src/CMakeFiles/VTFLib13.dir/FileWriter.cpp.o
[ 30%] Building CXX object src/CMakeFiles/VTFLib13.dir/VMTFile.cpp.o
[ 34%] Building CXX object src/CMakeFiles/VTFLib13.dir/ProcWriter.cpp.o
[ 38%] Building CXX object src/CMakeFiles/VTFLib13.dir/MemoryWriter.cpp.o
[ 46%] Building CXX object src/CMakeFiles/VTFLib13.dir/VMTGroupNode.cpp.o
[ 46%] Building CXX object src/CMakeFiles/VTFLib13.dir/VMTIntegerNode.cpp.o
[ 50%] Building CXX object src/CMakeFiles/VTFLib13.dir/VMTNode.cpp.o
[ 53%] Building CXX object src/CMakeFiles/VTFLib13.dir/VMTSingleNode.cpp.o
[ 57%] Building CXX object src/CMakeFiles/VTFLib13.dir/VMTStringNode.cpp.o
[ 61%] Building CXX object src/CMakeFiles/VTFLib13.dir/VMTValueNode.cpp.o
[ 65%] Building CXX object src/CMakeFiles/VTFLib13.dir/VMTWrapper.cpp.o
[ 69%] Building CXX object src/CMakeFiles/VTFLib13.dir/VTFFile.cpp.o
[ 73%] Building CXX object src/CMakeFiles/VTFLib13.dir/VTFLib.cpp.o
[ 76%] Building CXX object src/CMakeFiles/VTFLib13.dir/VTFMathlib.cpp.o
[ 80%] Building CXX object src/CMakeFiles/VTFLib13.dir/VTFWrapper.cpp.o
[ 84%] Building CXX object src/CMakeFiles/VTFLib13.dir/unix/Error.cpp.o
[ 88%] Building CXX object src/CMakeFiles/VTFLib13.dir/unix/FileWriter.cpp.o
[ 92%] Building CXX object src/CMakeFiles/VTFLib13.dir/unix/FileReader.cpp.o
[ 96%] Building CXX object src/CMakeFiles/VTFLib13.dir/unix/VTFLib.cpp.o
[100%] Linking CXX shared library libVTFLib13.so
[100%] Built target VTFLib13

pm  …/VTFLib/build   master   10:56  sudo make install
doas (pm@vix) password: 
Consolidate compiler generated dependencies of target VTFLib13
[100%] Built target VTFLib13
Install the project...
-- Install configuration: "Release"
-- Installing: /usr/lib64/pkgconfig/VTFLib13.pc
-- Symlinking VTFLib13.pc to VTFLib.pc
-- Installing: /usr/lib64/libVTFLib13.so
-- Set runtime path of "/usr/lib64/libVTFLib13.so" to ""
-- Installing: /usr/include/VTFLib13/Error.h
-- Installing: /usr/include/VTFLib13/FileReader.h
-- Installing: /usr/include/VTFLib13/FileWriter.h
-- Installing: /usr/include/VTFLib13/Float16.h
-- Installing: /usr/include/VTFLib13/MemoryReader.h
-- Installing: /usr/include/VTFLib13/MemoryWriter.h
-- Installing: /usr/include/VTFLib13/Proc.h
-- Installing: /usr/include/VTFLib13/ProcReader.h
-- Installing: /usr/include/VTFLib13/ProcWriter.h
-- Installing: /usr/include/VTFLib13/Reader.h
-- Installing: /usr/include/VTFLib13/Readers.h
-- Installing: /usr/include/VTFLib13/resource.h
-- Installing: /usr/include/VTFLib13/stdafx.h
-- Installing: /usr/include/VTFLib13/VMTFile.h
-- Installing: /usr/include/VTFLib13/VMTGroupNode.h
-- Installing: /usr/include/VTFLib13/VMTIntegerNode.h
-- Installing: /usr/include/VTFLib13/VMTNode.h
-- Installing: /usr/include/VTFLib13/VMTNodes.h
-- Installing: /usr/include/VTFLib13/VMTSingleNode.h
-- Installing: /usr/include/VTFLib13/VMTStringNode.h
-- Installing: /usr/include/VTFLib13/VMTValueNode.h
-- Installing: /usr/include/VTFLib13/VMTWrapper.h
-- Installing: /usr/include/VTFLib13/VTFDXTn.h
-- Installing: /usr/include/VTFLib13/VTFFile.h
-- Installing: /usr/include/VTFLib13/VTFFormat.h
-- Installing: /usr/include/VTFLib13/VTFLib.h
-- Installing: /usr/include/VTFLib13/VTFMathlib.h
-- Installing: /usr/include/VTFLib13/VTFWrapper.h
-- Installing: /usr/include/VTFLib13/Writer.h
-- Installing: /usr/include/VTFLib13/Writers.h
-- Installing: /usr/include/VTFLib13/config.h

```
Works for me.